### PR TITLE
only run on pull_request trigger.

### DIFF
--- a/.github/workflows/action_scanning.yml
+++ b/.github/workflows/action_scanning.yml
@@ -3,12 +3,6 @@ name: Scan GitHub Action workflows files for security issues
 
 on:
   pull_request: {}
-  workflow_dispatch: {}
-  push:
-    paths:
-      - '.github/workflows/**.ya?ml'
-  schedule:
-    - cron: '39 3 * * 3'
 
 permissions:
   contents: read


### PR DESCRIPTION
I believe this will fix the requirements for users doing direct push and allow it to run on PRs.