### PR TITLE
Update runners to ubuntu-24.04 from deprecated ubuntu-20.04 label

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   build:
     name: "Build Docs"
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-24.04'
     steps:
     - uses: 'actions/checkout@v4'
     - name: 'Generate HTML from Markdown'
@@ -30,7 +30,7 @@ jobs:
     environment:
       name: 'github-pages'
       url: '${{ steps.deployment.outputs.page_url }}'
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-24.04'
     needs: 'build'
     steps:
       - name: 'Deploy to GitHub Pages'


### PR DESCRIPTION
This is a LSC run by go/ghss to upgrade all depreacated ubuntu-20.04 runners to ubuntu-24.04.

On April 1, 2025, GitHub will stop supporting ubuntu-20.04 runners and workflows configured with this label will cease to run.  This PR is an attempt to save you work by doing the upgrade for you.

WARNING: We do not know if the updated label is compatiable with your workflow or not.

If you do not want to merge this PR, feel free to close it and deal with the problem yourselves.

More context and feedback: http://b/406537467
