### PR TITLE
chore: action version updates for commit_logging workflow

### DIFF
--- a/.github/workflows/commit_logging.yml
+++ b/.github/workflows/commit_logging.yml
@@ -36,14 +36,12 @@ jobs:
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@2dd133ffa2bc779c0854b1999e993c416c87164b' # ratchet:google-github-actions/auth@v0.3.0
+        uses: 'google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193' # ratchet:google-github-actions/auth@v2.1.10
         with:
-          access_token_lifetime: '900s'
           workload_identity_provider: 'projects/580543901798/locations/global/workloadIdentityPools/becle1b-wif-64840b/providers/becle1b-wif-64840b'
           service_account: 'github-automation-bot@bradegler-commit-log-exp-1b.iam.gserviceaccount.com'
           create_credentials_file: true
-          activate_credentials_file: true
-      - uses: 'actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c' # ratchet:actions/setup-python@v4
+      - uses: 'actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065' # ratchet:actions/setup-python@v5
         with:
           python-version: '3.11.2'
       - name: 'install_dependencies'


### PR DESCRIPTION
Never copy examples without looking at action version information 🤦 