### PR TITLE
Action Scanning: Only clone .github directory

### DIFF
--- a/.github/workflows/action_scanning.yml
+++ b/.github/workflows/action_scanning.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
     - name: 'Checkout PR Code'
       uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+      with:
+        fetch-depth: 1
+        sparse-checkout: '.github'
 
     - name: 'Check for Workflow Files'
       id: 'check_files'


### PR DESCRIPTION
Somehow this optimization didn't make its way here yet.